### PR TITLE
feat: verify proof

### DIFF
--- a/src/extrinsic_decoder.rs
+++ b/src/extrinsic_decoder.rs
@@ -26,13 +26,13 @@ use crate::{
 /// to prevent a stack overflow.
 const MAX_STACK_DEPTH: usize = 1000;
 
-struct TypeResolver {
+pub struct TypeResolver {
 	raw_type_id_to_types: BTreeMap<u32, Vec<Type>>,
 	stack_depth: AtomicUsize,
 }
 
 impl TypeResolver {
-	fn new<'a>(types: impl Iterator<Item = &'a Type>) -> Self {
+	pub fn new<'a>(types: impl Iterator<Item = &'a Type>) -> Self {
 		Self {
 			raw_type_id_to_types: types.fold(Default::default(), |mut map, ty| {
 				map.entry(ty.type_id.0).or_default().push(ty.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ use alloc::string::String;
 use extrinsic_decoder::{
 	decode_extrinsic_and_collect_type_ids, decode_extrinsic_parts_and_collect_type_ids,
 };
+pub use extrinsic_decoder::TypeResolver;
 use frame_metadata::RuntimeMetadata;
 
 use codec::{Encode, Decode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,13 @@
 extern crate alloc;
 
 use alloc::string::String;
+pub use extrinsic_decoder::TypeResolver;
 use extrinsic_decoder::{
 	decode_extrinsic_and_collect_type_ids, decode_extrinsic_parts_and_collect_type_ids,
 };
-pub use extrinsic_decoder::TypeResolver;
 use frame_metadata::RuntimeMetadata;
 
-use codec::{Encode, Decode};
+use codec::{Decode, Encode};
 
 use from_frame_metadata::FrameMetadataPrepared;
 use merkle_tree::MerkleTree;
@@ -38,10 +38,10 @@ pub use merkle_tree::Proof;
 mod extrinsic_decoder;
 mod from_frame_metadata;
 mod merkle_tree;
-use merkle_tree::{NodeIndex, get_hash};
+use merkle_tree::{get_hash, NodeIndex};
 
 pub mod types;
-use types::{MetadataDigest, Hash};
+use types::{Hash, MetadataDigest};
 
 /// Extra information that is required to generate the [`MetadataDigest`].
 #[derive(Debug, Clone, Encode, Decode)]
@@ -85,26 +85,27 @@ pub fn verify_metadata_digest(
 	proof: Proof,
 	extrinsic_metadata_hash: Hash,
 	extra_info: ExtraInfo,
-	expected_metadata_hash: Hash
+	expected_metadata_hash: Hash,
 ) -> bool {
 	let proof_hash = get_hash(
-    &mut &proof.leaf_indices[..], 
-    &mut &proof.leaves[..], 
-    &mut &proof.nodes[..],
-    NodeIndex(0)
-  );
+		&mut &proof.leaf_indices[..],
+		&mut &proof.leaves[..],
+		&mut &proof.nodes[..],
+		NodeIndex(0),
+	);
 
-  let metadata_hash = MetadataDigest::V1 { 
-    types_tree_root: proof_hash, 
-    extrinsic_metadata_hash: extrinsic_metadata_hash,
-    spec_version: extra_info.spec_version,
-    spec_name: extra_info.spec_name.clone(),
-    base58_prefix: extra_info.base58_prefix,
-    decimals: extra_info.decimals,
-    token_symbol: extra_info.token_symbol.clone() 
-  }.hash();
+	let metadata_hash = MetadataDigest::V1 {
+		types_tree_root: proof_hash,
+		extrinsic_metadata_hash,
+		spec_version: extra_info.spec_version,
+		spec_name: extra_info.spec_name.clone(),
+		base58_prefix: extra_info.base58_prefix,
+		decimals: extra_info.decimals,
+		token_symbol: extra_info.token_symbol.clone(),
+	}
+	.hash();
 
-  metadata_hash == expected_metadata_hash
+	metadata_hash == expected_metadata_hash
 }
 
 /// Generate a proof for the given `extrinsic` using the given `metadata`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,18 +27,24 @@ use extrinsic_decoder::{
 	decode_extrinsic_and_collect_type_ids, decode_extrinsic_parts_and_collect_type_ids,
 };
 use frame_metadata::RuntimeMetadata;
+
+use codec::{Encode, Decode};
+
 use from_frame_metadata::FrameMetadataPrepared;
 use merkle_tree::MerkleTree;
 pub use merkle_tree::Proof;
-use types::MetadataDigest;
 
 mod extrinsic_decoder;
 mod from_frame_metadata;
 mod merkle_tree;
+use merkle_tree::{NodeIndex, get_hash};
+
 pub mod types;
+use types::MetadataDigest;
+pub use types::Hash;
 
 /// Extra information that is required to generate the [`MetadataDigest`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Encode, Decode)]
 pub struct ExtraInfo {
 	/// The spec version of the runtime.
 	pub spec_version: u32,
@@ -72,6 +78,36 @@ pub fn generate_metadata_digest(
 		decimals: extra_info.decimals,
 		token_symbol: extra_info.token_symbol,
 	})
+}
+
+pub fn verify_metadata_digest(
+	proof: Proof,
+	extrinsic_metadata_hash: Hash,
+	extra_info: ExtraInfo,
+	expected_metadata_hash: Hash
+) -> Result<(), String> {
+	let proof_hash = get_hash(
+    &mut &proof.leaf_indices[..], 
+    &mut &proof.leaves[..], 
+    &mut &proof.nodes[..],
+    NodeIndex(0)
+  );
+
+  let metadata_hash = MetadataDigest::V1 { 
+    types_tree_root: proof_hash, 
+    extrinsic_metadata_hash: extrinsic_metadata_hash,
+    spec_version: extra_info.spec_version,
+    spec_name: extra_info.spec_name.clone(),
+    base58_prefix: extra_info.base58_prefix,
+    decimals: extra_info.decimals,
+    token_symbol: extra_info.token_symbol.clone() 
+  }.hash();
+
+  if metadata_hash == expected_metadata_hash {
+		Ok(())
+	} else {
+		Err("Metadata hash mismatch".into())
+	}
 }
 
 /// Generate a proof for the given `extrinsic` using the given `metadata`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,7 @@ mod merkle_tree;
 use merkle_tree::{NodeIndex, get_hash};
 
 pub mod types;
-use types::MetadataDigest;
-pub use types::Hash;
+use types::{MetadataDigest, Hash};
 
 /// Extra information that is required to generate the [`MetadataDigest`].
 #[derive(Debug, Clone, Encode, Decode)]
@@ -86,7 +85,7 @@ pub fn verify_metadata_digest(
 	extrinsic_metadata_hash: Hash,
 	extra_info: ExtraInfo,
 	expected_metadata_hash: Hash
-) -> Result<(), String> {
+) -> bool {
 	let proof_hash = get_hash(
     &mut &proof.leaf_indices[..], 
     &mut &proof.leaves[..], 
@@ -104,11 +103,7 @@ pub fn verify_metadata_digest(
     token_symbol: extra_info.token_symbol.clone() 
   }.hash();
 
-  if metadata_hash == expected_metadata_hash {
-		Ok(())
-	} else {
-		Err("Metadata hash mismatch".into())
-	}
+  metadata_hash == expected_metadata_hash
 }
 
 /// Generate a proof for the given `extrinsic` using the given `metadata`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub fn generate_metadata_digest(
 	})
 }
 
+/// Verifies that given proof matches and additional info matches [`MetadataDigest`] hash.
 pub fn verify_metadata_digest(
 	proof: Proof,
 	extrinsic_metadata_hash: Hash,

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -64,7 +64,7 @@ impl Ord for TypeId {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct NodeIndex(usize);
+pub struct NodeIndex(pub usize);
 
 impl NodeIndex {
 	/// Returns if this is the root node index.
@@ -349,6 +349,43 @@ impl MerkleTree {
 	}
 }
 
+pub fn get_hash(
+	leaf_indices: &mut &[u32],
+	leaves: &mut &[Type],
+	nodes: &mut &[Hash],
+	node_index: NodeIndex,
+) -> Hash {
+	let is_descendent = if leaf_indices.is_empty() {
+		false
+	} else {
+		let current_leaf = NodeIndex(leaf_indices[0] as usize);
+
+		if node_index == current_leaf {
+			let hash = blake3::hash(&leaves[0].encode());
+
+			*leaves = &leaves[1..];
+			*leaf_indices = &leaf_indices[1..];
+			return hash.into();
+		}
+
+		node_index.is_descendent(current_leaf)
+	};
+
+	if !is_descendent {
+		let res = nodes[0];
+		*nodes = &nodes[1..];
+		return res;
+	}
+
+	let left_child = node_index.left_child();
+	let left = get_hash(leaf_indices, leaves, nodes, left_child);
+
+	let right_child = node_index.right_child();
+	let right = get_hash(leaf_indices, leaves, nodes, right_child);
+
+	blake3::hash(&(left, right).encode()).into()
+}
+
 #[cfg(test)]
 mod tests {
 	use std::fs;
@@ -419,56 +456,6 @@ mod tests {
 		}
 	}
 
-	fn get_hash(
-		leaf_indices: &mut &[u32],
-		leaves: &mut &[Type],
-		nodes: &mut &[Hash],
-		node_index: NodeIndex,
-		merkle_tree: &MerkleTree,
-	) -> Hash {
-		let is_descendent = if leaf_indices.is_empty() {
-			false
-		} else {
-			let current_leaf = NodeIndex(leaf_indices[0] as usize);
-
-			if node_index == current_leaf {
-				let hash = blake3::hash(&leaves[0].encode());
-
-				*leaves = &leaves[1..];
-				*leaf_indices = &leaf_indices[1..];
-				return hash.into();
-			}
-
-			node_index.is_descendent(current_leaf)
-		};
-
-		if !is_descendent {
-			let res = nodes[0];
-			*nodes = &nodes[1..];
-			return res;
-		}
-
-		let left_child = node_index.left_child();
-		let left = get_hash(leaf_indices, leaves, nodes, left_child, merkle_tree);
-
-		assert_eq!(
-			left,
-			*merkle_tree.node_index_to_hash.get(&left_child).unwrap(),
-			"Found wrong {left_child:?}"
-		);
-
-		let right_child = node_index.right_child();
-		let right = get_hash(leaf_indices, leaves, nodes, right_child, merkle_tree);
-
-		assert_eq!(
-			right,
-			*merkle_tree.node_index_to_hash.get(&right_child).unwrap(),
-			"Found wrong {right_child:?}"
-		);
-
-		blake3::hash(&(left, right).encode()).into()
-	}
-
 	// `Balances::transfer_keep_alive`
 	const TEST_EXT: &str = "0x2d028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01bce7c8f572d39cee240e3d50958f68a5c129e0ac0d4eb9222de70abdfa8c44382a78eded433782e6b614a97d8fd609a3f20162f3f3b3c16e7e8489b2bd4fa98c070000000403008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a4828";
 	const TEST_CALL: &str =
@@ -523,7 +510,6 @@ mod tests {
 			&mut &proof.leaves[..],
 			&mut &proof.nodes[..],
 			NodeIndex(0),
-			&merkle_tree,
 		);
 		assert_eq!(
 			array_bytes::bytes2hex("0x", merkle_tree.root()),
@@ -618,7 +604,6 @@ mod tests {
 			&mut &proof.leaves[..],
 			&mut &proof.nodes[..],
 			NodeIndex(0),
-			&merkle_tree,
 		);
 		assert_eq!(
 			array_bytes::bytes2hex("0x", merkle_tree.root()),

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -5,7 +5,7 @@ use alloc::{
 	string::String,
 	vec::Vec,
 };
-use codec::{Compact, Encode, Decode};
+use codec::{Compact, Decode, Encode};
 use core::{cmp::Ordering, fmt::Debug, iter::Peekable};
 
 /// A node of a [`MerkleTree`].

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -5,7 +5,7 @@ use alloc::{
 	string::String,
 	vec::Vec,
 };
-use codec::{Compact, Encode};
+use codec::{Compact, Encode, Decode};
 use core::{cmp::Ordering, fmt::Debug, iter::Peekable};
 
 /// A node of a [`MerkleTree`].
@@ -140,7 +140,7 @@ impl NodeIndex {
 /// - `leaves`: `[u32, u16]`
 /// - `leaf_indices`: `[4, 6]`
 /// - `nodes`: `[hashOf(3), hashOf(5)]`
-#[derive(Clone, Debug, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub struct Proof {
 	/// The leaves of the tree.
 	///

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,8 @@
 use alloc::{string::String, vec::Vec};
-use codec::{Compact, Encode};
+use codec::{Compact, Encode, Decode};
 
 /// A reference to a type in the registry.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Default, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode, Default, Copy)]
 pub enum TypeRef {
 	#[codec(index = 0)]
 	Bool,
@@ -66,7 +66,7 @@ impl TypeRef {
 /// The hash type.
 pub type Hash = [u8; 32];
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub enum TypeDef {
 	/// A composite type (e.g. a struct or a tuple)
 	#[codec(index = 0)]
@@ -99,33 +99,33 @@ impl TypeDef {
 	}
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub struct Field {
 	pub name: Option<String>,
 	pub ty: TypeRef,
 	pub type_name: Option<String>,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub struct EnumerationVariant {
 	pub name: String,
 	pub fields: Vec<Field>,
 	pub index: Compact<u32>,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub struct TypeDefArray {
 	pub len: u32,
 	pub type_param: TypeRef,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Debug)]
 pub struct TypeDefBitSequence {
 	pub num_bytes: u8,
 	pub least_significant_bit_first: bool,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub struct Type {
 	/// The unique path to the type. Can be empty for built-in types
 	pub path: Vec<String>,
@@ -142,7 +142,7 @@ impl Type {
 	}
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub struct ExtrinsicMetadata {
 	/// Extrinsic version.
 	pub version: u8,
@@ -159,7 +159,7 @@ impl ExtrinsicMetadata {
 	}
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub struct SignedExtensionMetadata {
 	pub identifier: String,
 	pub included_in_extrinsic: TypeRef,
@@ -169,7 +169,7 @@ pub struct SignedExtensionMetadata {
 /// The metadata digest.
 ///
 /// The hash of this digest is the "metadata hash".
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode)]
 pub enum MetadataDigest {
 	Disabled,
 	V1 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use alloc::{string::String, vec::Vec};
-use codec::{Compact, Encode, Decode};
+use codec::{Compact, Decode, Encode};
 
 /// A reference to a type in the registry.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Encode, Decode, Default, Copy)]


### PR DESCRIPTION
## Purpose

This PR adds support for verifying metadata hashes from the CheckMetadataHash extension by introducing a new public API `verify_metadata_digest`. The function exposed in the library interface to allow consumers to verify the metadata hash embedded in the proof against an expected value.

To support reuse across the decoding and encoding logic several internal structs used in the proof format have been made public.